### PR TITLE
Update tests to pass explicit game ID

### DIFF
--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -20,7 +20,7 @@ from src.models.rule import Rule, TriggerCondition, RuleEffect, EffectType, RULE
 async def test_game_state_manager():
     """测试游戏状态管理"""
     game_manager = GameStateManager()
-    state = game_manager.new_game()
+    state = game_manager.new_game("test_game_001")
     
     assert state is not None
     assert state.game_id is not None
@@ -48,7 +48,7 @@ async def test_rule_creation():
 async def test_npc_behavior():
     """测试NPC行为系统"""
     game_manager = GameStateManager()
-    game_manager.new_game()
+    game_manager.new_game("test_game_001")
     npc_behavior = NPCBehavior(game_manager)
     
     # 随机选一个NPC测试
@@ -66,7 +66,7 @@ async def test_npc_behavior():
 async def test_rule_executor():
     """测试规则执行引擎"""
     game_manager = GameStateManager()
-    game_manager.new_game()
+    game_manager.new_game("test_game_001")
     rule_executor = RuleExecutor(game_manager)
     
     # 添加测试规则
@@ -99,7 +99,7 @@ async def test_rule_executor():
 async def test_game_save_load():
     """测试游戏保存/加载"""
     game_manager = GameStateManager()
-    game_manager.new_game()
+    game_manager.new_game("test_game_001")
     
     # 保存游戏
     save_path = game_manager.save_game("test_save")


### PR DESCRIPTION
## Summary
- update unit tests to pass a specific game ID when starting a new game

## Testing
- `python run_tests_fixed.py` *(fails: PydanticDeprecatedSince20 warning configuration error)*

------
https://chatgpt.com/codex/tasks/task_e_6885a127703c83289f591e10de0fd5d5