### PR TITLE
Add generate_dialogue_async wrapper

### DIFF
--- a/src/api/deepseek_client.py
+++ b/src/api/deepseek_client.py
@@ -250,6 +250,32 @@ class DeepSeekClient:
             self.cache.set(cache_key, {"npcs": len(npc_states)}, {"dialogues": dialogues})
         
         return dialogues
+
+    async def generate_dialogue_async(
+        self,
+        context: str,
+        participants: List[str],
+        max_tokens: Optional[int] = None,
+    ) -> List[Dict[str, str]]:
+        """Simplified async wrapper for :meth:`generate_dialogue`.
+
+        Args:
+            context: 场景描述文本
+            participants: 参与对话的角色名称列表
+            max_tokens: 与 ``generate_dialogue`` 兼容的占位参数
+
+        Returns:
+            对话列表 ``[{"speaker": str, "text": str}]``
+        """
+
+        npc_states = [{"name": name} for name in participants]
+        scene_context = {"description": context}
+
+        # 目前 ``generate_dialogue`` 并未暴露 ``max_tokens`` 参数，
+        # 因此在此仅保持接口兼容，不直接使用该值。
+        _ = max_tokens
+
+        return await self.generate_dialogue(npc_states, scene_context)
     
     async def evaluate_rule(
         self,

--- a/tests/api/test_deepseek_api.py
+++ b/tests/api/test_deepseek_api.py
@@ -41,13 +41,14 @@ class TestDeepSeekAPI:
             response = await client.generate_dialogue_async(
                 context="测试场景：玩家们在客厅相遇",
                 participants=["张三", "李四"],
-                max_tokens=100
+                max_tokens=100,
             )
-            
+
             assert response is not None
-            assert isinstance(response, str)
+            assert isinstance(response, list)
             assert len(response) > 0
-            print(f"✓ API响应成功: {response[:50]}...")
+            assert all("speaker" in d and "text" in d for d in response)
+            print(f"✓ API响应成功: {response[0]['text'][:50]}...")
             
         except Exception as e:
             pytest.fail(f"API连接失败: {e}")
@@ -190,10 +191,11 @@ class TestAPIIntegration:
         dialogue = await client.generate_dialogue_async(
             context="夜晚，两个陌生人被困在了一栋诡异的房子里",
             participants=[npc["name"] for npc in npcs],
-            max_tokens=150
+            max_tokens=150,
         )
-        assert dialogue is not None
-        print(f"   ✓ 对话生成: {dialogue[:80]}...")
+        assert isinstance(dialogue, list)
+        assert len(dialogue) > 0
+        print(f"   ✓ 对话生成: {dialogue[0]['text'][:80]}...")
         
         # 3. 评估规则
         print("3. 评估规则...")


### PR DESCRIPTION
## Summary
- implement `generate_dialogue_async` wrapper in `DeepSeekClient`
- update tests to use the list-based response

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6885acdca0948328961f64afc85fb92b