### PR TITLE
Implement time range check for Rule.can_trigger

### DIFF
--- a/src/models/rule.py
+++ b/src/models/rule.py
@@ -114,7 +114,19 @@ class Rule(BaseModel):
         # 检查时间条件
         if self.trigger.time_range:
             current_time = context.get('current_time', '00:00')
-            # TODO: 实现时间范围检查逻辑
+            try:
+                current = int(current_time.replace(":", ""))
+                start = int(self.trigger.time_range["from"].replace(":", ""))
+                end = int(self.trigger.time_range["to"].replace(":", ""))
+
+                if start <= end:
+                    if not (start <= current <= end):
+                        return False
+                else:
+                    if not (current >= start or current <= end):
+                        return False
+            except Exception:
+                return False
             
         # 检查地点条件
         if self.trigger.location:

--- a/tests/unit/test_rule_time_range.py
+++ b/tests/unit/test_rule_time_range.py
@@ -1,0 +1,36 @@
+import pytest
+from src.models.rule import Rule, TriggerCondition, RuleEffect, EffectType
+
+
+@pytest.mark.unit
+def test_time_range_normal_interval():
+    rule = Rule(
+        id="r1",
+        name="normal",
+        trigger=TriggerCondition(action="act", time_range={"from": "08:00", "to": "12:00"}),
+        effect=RuleEffect(type=EffectType.FEAR_GAIN, fear_gain=10)
+    )
+
+    context_in = {"current_time": "09:00", "actor_location": None, "actor_items": []}
+    context_out = {"current_time": "13:00", "actor_location": None, "actor_items": []}
+
+    assert rule.can_trigger(context_in) is True
+    assert rule.can_trigger(context_out) is False
+
+
+@pytest.mark.unit
+def test_time_range_overnight_interval():
+    rule = Rule(
+        id="r2",
+        name="overnight",
+        trigger=TriggerCondition(action="act", time_range={"from": "22:00", "to": "02:00"}),
+        effect=RuleEffect(type=EffectType.FEAR_GAIN, fear_gain=10)
+    )
+
+    context_in_late = {"current_time": "23:30", "actor_location": None, "actor_items": []}
+    context_in_early = {"current_time": "01:30", "actor_location": None, "actor_items": []}
+    context_out = {"current_time": "03:00", "actor_location": None, "actor_items": []}
+
+    assert rule.can_trigger(context_in_late) is True
+    assert rule.can_trigger(context_in_early) is True
+    assert rule.can_trigger(context_out) is False


### PR DESCRIPTION
## Summary
- handle time range in `Rule.can_trigger`
- add tests for normal and overnight time ranges

## Testing
- `python run_tests_fixed.py` *(fails: Pydantic not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6885b21a0ccc83288a2885fc4af1da6f