### PR TITLE
Add return values for environment helpers

### DIFF
--- a/src/core/rule_executor.py
+++ b/src/core/rule_executor.py
@@ -277,10 +277,11 @@ class RuleExecutor:
         else:
             logger.warning(f"未知的副作用: {side_effect}")
             
-    def _add_scene_effect(self, location: str, effect: str):
+    def _add_scene_effect(self, location: str, effect: str) -> bool:
         """添加场景效果"""
-        # TODO: 实现场景效果系统
+        # TODO: 接入真实场景系统
         logger.info(f"场景效果: {location} - {effect}")
+        return True
         
     def _alert_nearby_npcs(self, location: str):
         """警告附近的NPC"""
@@ -291,15 +292,17 @@ class RuleExecutor:
                 "suspicion": min(100, npc.get("suspicion", 0) + 5)
             })
             
-    def _change_room_temp(self, location: str, change: int):
+    def _change_room_temp(self, location: str, change: int) -> bool:
         """改变房间温度"""
-        # TODO: 实现环境系统
+        # TODO: 接入真实环境系统
         logger.info(f"温度变化: {location} {change:+d}°C")
+        return True
         
-    def _trigger_light_event(self, location: str):
+    def _trigger_light_event(self, location: str) -> bool:
         """触发灯光事件"""
-        # TODO: 实现灯光系统
+        # TODO: 接入真实灯光系统
         logger.info(f"灯光闪烁: {location}")
+        return True
         
     def update_cooldowns(self):
         """更新所有规则的冷却时间"""

--- a/tests/unit/test_rule_executor_helpers.py
+++ b/tests/unit/test_rule_executor_helpers.py
@@ -1,0 +1,13 @@
+import pytest
+from src.core.game_state import GameStateManager
+from src.core.rule_executor import RuleExecutor
+
+@pytest.mark.unit
+def test_rule_executor_helpers_return():
+    gm = GameStateManager()
+    gm.new_game("helper_test")
+    executor = RuleExecutor(gm)
+
+    assert executor._add_scene_effect("bathroom", "blood") is True
+    assert executor._change_room_temp("kitchen", -5) is True
+    assert executor._trigger_light_event("hall") is True


### PR DESCRIPTION
## Summary
- return boolean success for placeholder environment helpers
- note TODOs for scene, environment and light systems
- test helper functions directly

## Testing
- `python -m pytest tests/unit/test_rule_executor_helpers.py -v` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6885b630d0388328b06ec24439522c47