### PR TITLE
Add GamePhase and GameMode enums

### DIFF
--- a/src/cli_game.py
+++ b/src/cli_game.py
@@ -11,7 +11,8 @@ from datetime import datetime
 # 添加项目根目录到Python路径
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
-from src.core.game_state import GameStateManager, GamePhase, GameMode
+from src.core.game_state import GameStateManager
+from src.core.enums import GamePhase, GameMode
 from src.core.rule_executor import RuleExecutor, RuleContext
 from src.core.npc_behavior import NPCBehavior
 from src.models.rule import Rule, TriggerCondition, RuleEffect, EffectType, RULE_TEMPLATES

--- a/src/core/enums.py
+++ b/src/core/enums.py
@@ -1,0 +1,17 @@
+from enum import Enum
+
+class GamePhase(str, Enum):
+    """遊戲階段枚舉"""
+    SETUP = "setup"
+    MORNING_DIALOGUE = "morning_dialogue"
+    EVENING_DIALOGUE = "evening_dialogue"
+    ACTION = "action"
+    RESOLUTION = "resolution"
+
+class GameMode(str, Enum):
+    """遊戲模式枚舉"""
+    BACKSTAGE = "backstage"
+    IN_SCENE = "in_scene"
+
+__all__ = ["GamePhase", "GameMode"]
+


### PR DESCRIPTION
## Summary
- add `GamePhase` and `GameMode` enums
- switch `GameState` to use the new enums
- adjust CLI imports

## Testing
- `python run_tests_fixed.py` *(fails: PydanticDeprecatedSince20 warning class missing)*

------
https://chatgpt.com/codex/tasks/task_e_6885be1947b08328887cd568c3ed7bea