### PR TITLE
Support integer log levels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ DEEPSEEK_MODEL=deepseek-chat
 
 # Game Configuration
 GAME_DEBUG=false
-GAME_LOG_LEVEL=INFO
+GAME_LOG_LEVEL=INFO  # 或使用數值，例如 20
 
 # Web Configuration (for future use)
 WEB_HOST=0.0.0.0

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ python rulek.py test integration
 
 ```env
 DEEPSEEK_API_KEY=your_api_key_here
-LOG_LEVEL=INFO
+LOG_LEVEL=INFO  # 也可以使用數字值，例如 20
 DEBUG=False
 ```
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -28,7 +28,7 @@
 ```bash
 # API配置
 DEEPSEEK_API_KEY=your_production_api_key
-LOG_LEVEL=WARNING
+LOG_LEVEL=WARNING  # 也可以使用數字值，例如 30
 DEBUG=False
 
 # 数据库配置（如果使用）

--- a/rulek.py
+++ b/rulek.py
@@ -119,7 +119,7 @@ def main():
     
     args = parser.parse_args()
     
-    # 设置日志级别
+    # 设置日志级别（支持传入 logging.INFO 或 "INFO" 等值）
     log_level = logging.DEBUG if args.debug else logging.INFO
     logger = setup_logger("main", level=log_level)
     

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -63,14 +63,29 @@ class ColoredFormatter(logging.Formatter):
 
 def setup_logger(
     name: str,
-    level: str = "INFO",
+    level: str | int = "INFO",
     log_file: Optional[str] = None,
     console: bool = True
 ) -> logging.Logger:
-    """设置日志器"""
-    
+    """设置日志器
+
+    Parameters
+    ----------
+    name : str
+        日志器名称
+    level : str | int, optional
+        日志级别，可以是 ``"INFO"`` 这样的字符串或 ``logging.INFO`` 的整数值。
+    log_file : Optional[str], optional
+        如果提供则写入指定的日志文件
+    console : bool, optional
+        是否输出到控制台
+    """
+
     logger = logging.getLogger(name)
-    logger.setLevel(LOG_LEVELS.get(level.upper(), logging.INFO))
+    if isinstance(level, int):
+        logger.setLevel(level)
+    else:
+        logger.setLevel(LOG_LEVELS.get(str(level).upper(), logging.INFO))
     
     # 清除现有处理器
     logger.handlers.clear()

--- a/web/backend/README.md
+++ b/web/backend/README.md
@@ -120,7 +120,7 @@ backend/
 创建 `.env` 文件（如果需要）：
 ```
 DEEPSEEK_API_KEY=your_api_key_here
-LOG_LEVEL=INFO
+LOG_LEVEL=INFO  # 或數值，例如 20
 ```
 
 ### 日志


### PR DESCRIPTION
## Summary
- expand `setup_logger` to accept numeric levels
- clarify log level usage in `rulek.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6885e1f454b48328b713e608c74695c5