### PR TITLE
Update save_game return type

### DIFF
--- a/main_game.py
+++ b/main_game.py
@@ -403,8 +403,9 @@ class RuleKGame:
         
     def save_game(self):
         """保存游戏"""
-        if self.game_state.save_game():
-            self.cli.print_success("游戏已保存！")
+        path = self.game_state.save_game()
+        if path:
+            self.cli.print_success(f"游戏已保存到: {path}")
         else:
             self.cli.print_error("保存失败！")
         self.cli.get_input("\n按回车继续...")

--- a/main_game_v2.py
+++ b/main_game_v2.py
@@ -690,8 +690,9 @@ class RuleKGame:
         self.game_state.extra_data["npcs_full"] = npc_data
         self.game_state.extra_data["last_dialogue_turn"] = self.last_dialogue_turn
         
-        if self.game_state.save_game():
-            self.cli.print_success("游戏已保存！")
+        path = self.game_state.save_game()
+        if path:
+            self.cli.print_success(f"游戏已保存到: {path}")
         else:
             self.cli.print_error("保存失败！")
         self.cli.get_input("\n按回车继续...")

--- a/run_tests_fixed.py
+++ b/run_tests_fixed.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 def main():
     """运行测试，忽略已知的警告"""
-    project_root = Path(__file__).parent.parent
+    project_root = Path(__file__).parent
     os.chdir(project_root)
     
     print("🧪 规则怪谈管理者 - 测试运行器（已修复版）")
@@ -25,9 +25,7 @@ def main():
         "tests/",
         "-v",                           # 详细输出
         "--tb=short",                   # 简短回溯
-        "--asyncio-mode=auto",          # 自动异步模式
         "-W", "ignore::DeprecationWarning",  # 忽略弃用警告
-        "-W", "ignore::PydanticDeprecatedSince20",  # 忽略Pydantic警告
         "--color=yes",                  # 彩色输出
     ]
     

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -103,7 +103,7 @@ async def test_game_save_load():
     
     # 保存游戏
     save_path = game_manager.save_game("test_save")
-    assert save_path is not None
+    assert isinstance(save_path, str)
     
     # 创建新的管理器并加载
     new_manager = GameStateManager()


### PR DESCRIPTION
## Summary
- modify `GameStateManager.save_game` to dump NPC objects and return file path
- update CLI and game scripts to use new return type
- expect string path in unit test
- tweak test runner

## Testing
- `python run_tests_fixed.py` *(fails: ModuleNotFoundError: No module named 'httpx' and 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6885e5121a34832893f5972d2377776a