### PR TITLE
Fix missing imports in deepseek helpers

### DIFF
--- a/src/api/deepseek_helpers.py
+++ b/src/api/deepseek_helpers.py
@@ -1,3 +1,9 @@
+from .deepseek_client import DeepSeekClient, APIConfig
+from src.utils.config import get_deepseek_config, is_test_mode
+from src.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
 # 便捷函数：从config目录或环境变量创建客户端
 async def create_default_client() -> DeepSeekClient:
     """创建默认配置的客户端"""


### PR DESCRIPTION
## Summary
- add missing imports for `DeepSeekClient`, `APIConfig`, config helpers, and logger
- instantiate a logger for the module

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6885ea2b405c832886d9839396b7b549