### PR TITLE
Fix startup issues for backend and frontend

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,9 +19,9 @@ flake8==6.1.0
 mypy==1.7.1
 
 # Web开发（未来使用）
-# fastapi==0.104.1
-# uvicorn[standard]==0.24.0
-# websockets==12.0
+fastapi==0.104.1
+uvicorn[standard]==0.24.0
+websockets==12.0
 
 # 注意事项：
 # 1. Python 3.7+ 必需（使用了asyncio）

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 # 快速启动脚本 - 同时启动后端和前端
 
 echo "🎮 启动规则怪谈管理者..."
@@ -28,6 +29,12 @@ echo "✅ 后端 PID: $BACKEND_PID"
 # 等待后端启动
 sleep 3
 
+# 检查后端是否仍在运行
+if ! kill -0 $BACKEND_PID 2>/dev/null; then
+    echo "❌ 后端启动失败"
+    exit 1
+fi
+
 # 检查前端依赖
 echo "📦 检查前端依赖..."
 cd web/frontend
@@ -44,6 +51,13 @@ echo "✅ 前端 PID: $FRONTEND_PID"
 
 # 等待前端启动
 sleep 3
+
+# 检查前端是否仍在运行
+if ! kill -0 $FRONTEND_PID 2>/dev/null; then
+    echo "❌ 前端启动失败"
+    kill $BACKEND_PID 2>/dev/null
+    exit 1
+fi
 
 echo ""
 echo "✨ 规则怪谈管理者已启动！"

--- a/web/backend/run_server.py
+++ b/web/backend/run_server.py
@@ -12,7 +12,7 @@ sys.path.insert(0, str(project_root))
 
 if __name__ == "__main__":
     uvicorn.run(
-        "app:app",
+        "web.backend.app:app",
         host="0.0.0.0",
         port=8000,
         reload=True,

--- a/web/frontend/tsconfig.node.json
+++ b/web/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}


### PR DESCRIPTION
## Summary
- ensure FastAPI dependencies installed
- add startup checks in start.sh
- fix backend module path for uvicorn
- provide Node tsconfig for Vite

## Testing
- `bash start.sh` *(fails: ModuleNotFoundError: No module named 'uvicorn' before fix)*

------
https://chatgpt.com/codex/tasks/task_e_6885f6f8d34083289ece3cf0ff0c2a39