### PR TITLE
Fix CLI state fields compatibility

### DIFF
--- a/src/managers/save_manager.py
+++ b/src/managers/save_manager.py
@@ -271,6 +271,7 @@ class SaveManager:
         return {
             "game_id": state.game_id,
             "turn": state.turn,
+            "day": state.day,
             "phase": state.phase,
             "fear_points": state.fear_points,
             "current_time": state.current_time,
@@ -344,12 +345,13 @@ class SaveManager:
     
     def _deserialize_game_state(self, data: Dict[str, Any]) -> GameState:
         """反序列化游戏状态"""
-        state = GameState()
+        state = GameState(game_id=data.get("game_id", "unknown"))
         
         # 恢复基本属性
-        for key in ["game_id", "turn", "phase", "fear_points", "current_time"]:
+        for key in ["game_id", "turn", "day", "phase", "fear_points", "current_time"]:
             if key in data:
                 setattr(state, key, data[key])
+        state.current_turn = state.turn
         
         # 恢复集合类型
         state.active_rules = set(data.get("active_rules", []))

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -23,7 +23,11 @@ class Config:
     
     def _load_env(self):
         """加载环境变量"""
-        from dotenv import find_dotenv, load_dotenv
+        try:
+            from dotenv import find_dotenv, load_dotenv
+        except ImportError:
+            logger.warning("python-dotenv 未安装，跳过加载 .env 文件")
+            return
 
         # 使用绝对路径查找 .env，兼容不同工作目录
         search_path = self.project_root / ".env"


### PR DESCRIPTION
## Summary
- add `day` and alias property `current_time` to `GameState`
- keep legacy `turn` value in sync when advancing turns
- persist new fields in save manager
- allow running without `python-dotenv`

## Testing
- `python rulek.py cli` *(fails: No module named 'pydantic')*
- `pytest -q` *(fails: httpx/pydantic missing)*

------
https://chatgpt.com/codex/tasks/task_e_68865179d0e8832883ac5d456bd257a3