### PR TITLE
Add compatibility for legacy event log fields

### DIFF
--- a/src/core/game_state.py
+++ b/src/core/game_state.py
@@ -35,6 +35,7 @@ class GameState:
 
     # 规则
     active_rules: List[str] = field(default_factory=list)
+    events_history: List[Dict[str, Any]] = field(default_factory=list)
     turn: int = 0  # 当前回合（与current_turn同步）
 
     # 兼容旧字段
@@ -46,6 +47,15 @@ class GameState:
     @current_time.setter
     def current_time(self, value: str):
         self.time_of_day = value
+
+    @property
+    def event_log(self) -> List[Dict[str, Any]]:
+        """向后兼容的事件日志字段"""
+        return self.events_history
+
+    @event_log.setter
+    def event_log(self, value: List[Dict[str, Any]]):
+        self.events_history = value
     
     # 角色
     npcs: Dict[str, Dict[str, Any]] = field(default_factory=dict)
@@ -67,6 +77,7 @@ class GameState:
             "time_of_day": self.time_of_day,
             "current_time": self.current_time,
             "active_rules": self.active_rules,
+            "events_history": self.events_history,
             "total_fear_gained": self.total_fear_gained,
             "npcs_died": self.npcs_died,
             "rules_triggered": self.rules_triggered,

--- a/src/managers/save_manager.py
+++ b/src/managers/save_manager.py
@@ -276,12 +276,12 @@ class SaveManager:
             "fear_points": state.fear_points,
             "current_time": state.current_time,
             "active_rules": list(state.active_rules),
-            "events_history": state.events_history[-100:],  # 只保存最近100条事件
+            "events_history": getattr(state, "events_history", getattr(state, "event_log", []))[-100:],  # 只保存最近100条事件
             "statistics": {
                 "total_fear_gained": state.total_fear_gained,
                 "npcs_died": state.npcs_died,
                 "rules_triggered": state.rules_triggered,
-                "rules_discovered": state.rules_discovered
+                "rules_discovered": getattr(state, "rules_discovered", 0)
             }
         }
     
@@ -355,7 +355,8 @@ class SaveManager:
         
         # 恢复集合类型
         state.active_rules = set(data.get("active_rules", []))
-        state.events_history = data.get("events_history", [])
+        events = data.get("events_history", data.get("event_log", []))
+        state.events_history = events
         
         # 恢复统计信息
         stats = data.get("statistics", {})


### PR DESCRIPTION
## Summary
- add `events_history` and `event_log` alias to `GameState`
- handle legacy event log and missing `rules_discovered` in `SaveManager`

## Testing
- `python rulek.py cli` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `python rulek.py test` *(fails: Could not find a version that satisfies the requirement pydantic)*
- `./start.sh` *(fails: Could not find a version that satisfies the requirement pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_688654540c6083289e2d61b0e042bb5e