### PR TITLE
Fix pause recursion and add test

### DIFF
--- a/src/cli_game.py
+++ b/src/cli_game.py
@@ -6,11 +6,11 @@ import os
 
 
 # --- test-friendly pause helper ---
-import os
 def _pause():
-    if os.getenv('PYTEST_RUNNING') == '1':
+    """Utility pause function used in CLI flows."""
+    if os.getenv("PYTEST_RUNNING") == "1":
         return
-    _pause()
+    input("按回车继续...")
 # --- end helper ---
 import sys
 import asyncio

--- a/tests/cli/test_cli_game.py
+++ b/tests/cli/test_cli_game.py
@@ -642,3 +642,25 @@ class TestIntegration:
             data = json.load(f)
             assert data['state']['current_turn'] == 1
             assert len(data['rules']) == 1
+
+
+class TestPauseFunction:
+    """测试暂停函数 _pause"""
+
+    def test_pause_skips_in_pytest(self, monkeypatch):
+        """环境变量设置时应立即返回，不调用 input"""
+        from src.cli_game import _pause
+
+        called = False
+
+        def fake_input(prompt=""):
+            nonlocal called
+            called = True
+            return ""
+
+        monkeypatch.setenv("PYTEST_RUNNING", "1")
+        monkeypatch.setattr("builtins.input", fake_input)
+
+        _pause()
+
+        assert called is False


### PR DESCRIPTION
## Summary
- prevent recursion in `_pause()` in `src/cli_game.py`
- add a unit test ensuring `_pause()` exits immediately when `PYTEST_RUNNING=1`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68872f8c1a248328be7e4a8943ad2c13