### PR TITLE
Fix fear bonus handler and add unit test

### DIFF
--- a/src/core/rule_executor.py
+++ b/src/core/rule_executor.py
@@ -340,7 +340,7 @@ class RuleExecutor:
             logger.info(f"副作用 {side_effect} 应用成功")
             # 如果副作用产生了额外恐惧值，添加到游戏中
             if result.get("fear_bonus"):
-                self.game_manager.gain_fear_points(
+                self.game_manager.add_fear_points(
                     result["fear_bonus"],
                     f"副作用: {side_effect}"
                 )

--- a/tests/unit/test_rule_executor_side_effects.py
+++ b/tests/unit/test_rule_executor_side_effects.py
@@ -1,0 +1,19 @@
+import pytest
+from src.core.game_state import GameStateManager
+from src.core.rule_executor import RuleExecutor, RuleContext
+
+
+def test_side_effect_fear_bonus_increases_fear_points():
+    gm = GameStateManager()
+    gm.new_game("side_effect_fear")
+    executor = RuleExecutor(gm)
+
+    # 取任意NPC作为触发者
+    npc = list(gm.state.npcs.values())[0]
+
+    context = RuleContext(actor=npc, action="test", game_state=gm.state.to_dict())
+    initial_fear = gm.state.fear_points
+
+    executor._apply_side_effect("blood_message", context)
+
+    assert gm.state.fear_points > initial_fear


### PR DESCRIPTION
## Summary
- ensure side effect fear bonus uses `add_fear_points`
- add test to verify fear bonus increases game fear points

## Testing
- `pytest tests/unit/test_rule_executor_side_effects.py::test_side_effect_fear_bonus_increases_fear_points -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68873501280083289322637178764ffc