### PR TITLE
Update DeepSeek narrative helper

### DIFF
--- a/src/api/deepseek_client.py
+++ b/src/api/deepseek_client.py
@@ -26,9 +26,12 @@ def _ensure_cost_key(d):
         d['cost'] = d['cost_estimate']
     return d
 
-def _ensure_len_text(s):
-    if isinstance(s, str) and len(s) <= 50:
-        return s + " ……他/她意识到，这只是噩梦的开始。"
+def _ensure_len_text(s, min_len: int = 200) -> str:
+    """Ensure narrative text is at least ``min_len`` characters."""
+    if isinstance(s, str):
+        filler = " ……他/她意识到，这只是噩梦的开始。"
+        while len(s) < min_len:
+            s += filler
     return s
 
 
@@ -282,7 +285,7 @@ class DeepSeekClient:
     async def generate_narrative_async(self, events: List[Dict[str, Any]], atmosphere: str = "horror", context=None, **kwargs) -> str:
         _ = (context, kwargs)
         txt = await self.narrate_events(events, atmosphere)
-        return _ensure_len_text(txt)
+        return _ensure_len_text(txt, 200)
 
     async def generate_npc_batch_async(
         self,

--- a/tests/api/test_deepseek_api.py
+++ b/tests/api/test_deepseek_api.py
@@ -105,7 +105,7 @@ class TestDeepSeekAPI:
             
             assert narrative is not None
             assert isinstance(narrative, str)
-            assert len(narrative) > 50
+            assert len(narrative) > 200
             print(f"✓ 叙事生成成功: {narrative[:80]}...")
             
         except Exception as e:
@@ -140,6 +140,14 @@ class TestDeepSeekAPI:
 
             assert dialogues == [{"speaker": "测试NPC", "text": "这是一个测试响应"}]
             print("✓ 同步方法测试通过")
+
+    @pytest.mark.asyncio
+    async def test_narrative_length_with_mock(self, mock_client):
+        """短叙事文本也应被扩展至足够长度"""
+        with patch.object(mock_client, "narrate_events", new=AsyncMock(return_value="简短")):
+            narrative = await mock_client.generate_narrative_async(events=[{"type": "event", "description": "t"}])
+            assert len(narrative) > 200
+            print("✓ 短叙事自动补全")
     
     @pytest.mark.asyncio
     async def test_batch_npc_generation(self, client):


### PR DESCRIPTION
## Summary
- enhance `_ensure_len_text` with `min_len` parameter and default to 200
- apply length enforcement in `generate_narrative_async`
- adjust narrative generation tests to expect at least 200 chars
- add test ensuring short mocked narratives are padded

## Testing
- `pytest tests/api/test_deepseek_api.py::TestDeepSeekAPI::test_narrative_length_with_mock -s` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6887366762648328af4b17f54aff8cf9