### PR TITLE
Fix AI pipeline import error

### DIFF
--- a/src/ai/turn_pipeline.py
+++ b/src/ai/turn_pipeline.py
@@ -3,6 +3,7 @@
 AI回合管线
 负责协调AI生成的对话、行动和叙事
 """
+from __future__ import annotations
 import logging
 from typing import Dict, Any, List, Optional, Tuple
 from datetime import datetime


### PR DESCRIPTION
## Summary
- postpone evaluation of type hints in `turn_pipeline.py` to avoid runtime NameError

## Testing
- `python verify_ai_integration.py`
- `python test_ai_integration.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68875da0e0d88328894b3134787c7de8