### PR TITLE
Fix event printing logic

### DIFF
--- a/src/cli_game.py
+++ b/src/cli_game.py
@@ -100,6 +100,11 @@ class CLIGame:
             
         print("\n📋 最近事件:")
         for event in events:
+            if hasattr(event, "to_dict"):
+                event = event.to_dict()
+            elif not isinstance(event, dict):
+                event = {"description": str(event)}
+
             time = event.get("game_time", "")
             type_ = event.get("type", "unknown")
             


### PR DESCRIPTION
## Summary
- allow `print_recent_events` to handle event objects with `to_dict()`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68884d597f98832880c048b91d51998d