### PR TITLE
Fix difficulty property indent

### DIFF
--- a/src/core/game_state.py
+++ b/src/core/game_state.py
@@ -443,7 +443,7 @@ class GameStateManager:
         """当前回合数"""
         return self.state.current_turn if self.state else 0
         
-        @property
+    @property
     def difficulty(self) -> str:
         """获取当前游戏难度"""
         return self.state.difficulty if self.state else "normal"


### PR DESCRIPTION
## Summary
- align `difficulty` property with `current_turn` in `game_state.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `python verify_fixes_final.py` *(fails: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68884edad9b88328a4002d2a4a0b4039