### PR TITLE
新增文本长度检查工具

### DIFF
--- a/src/core/narrator.py
+++ b/src/core/narrator.py
@@ -58,7 +58,8 @@ class Narrator:
                 # 调用AI生成叙事
                 narrative = await self.deepseek_client.generate_narrative_text(
                     events=event_descriptions,
-                    time_of_day=game_state.time_of_day
+                    time_of_day=game_state.time_of_day,
+                    min_len=200,
                 )
                 return narrative
             except Exception as e:


### PR DESCRIPTION
## Summary
- 在 `DeepSeekClient` 中加入 `_ensure_len_text` 方法，支持自定义最短长度
- 生成叙事文本时使用该方法保证内容长度
- `narrate_events` 与 `generate_narrative_async` 新增 `min_len` 参数
- `Narrator` 调用 `generate_narrative_text` 时传入 `min_len`

## Testing
- `pytest -q` *(失败：缺少 httpx、pydantic 等依赖)*

------
https://chatgpt.com/codex/tasks/task_e_68885444dc14832891f7a5fc338ae2b2