### PR TITLE
Handle cost_estimate in rule evaluation

### DIFF
--- a/src/api/deepseek_client.py
+++ b/src/api/deepseek_client.py
@@ -403,7 +403,11 @@ class DeepSeekClient:
             if not success:
                 logger.error(f"解析规则评估失败: {error}")
                 parsed_data = json.loads(self._extract_json(content))
-            
+
+            # 如果缺少cost但有cost_estimate，则补充cost字段
+            if isinstance(parsed_data, dict) and "cost" not in parsed_data and "cost_estimate" in parsed_data:
+                parsed_data["cost"] = parsed_data["cost_estimate"]
+
             # 验证并返回
             return RuleEvalResult.parse_obj(parsed_data)
             


### PR DESCRIPTION
## Summary
- if `evaluate_rule_nl` only returns `cost_estimate`, map it to `cost`

## Testing
- `python rulek.py test unit` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_688855f2dbdc8328854a3456ef34517d