### PR TITLE
Fix NPCTrait import error

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -2,6 +2,6 @@
 模型子包统一导出
 """
 
-from .npc import NPC, NPCTrait   # noqa: F401
+from .npc import NPC  # noqa: F401
 from .rule import Rule           # noqa: F401
 from .event import Event, EventType  # 新增导出  # noqa: F401


### PR DESCRIPTION
## Summary
- remove unused `NPCTrait` import

## Testing
- `python rulek.py test` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68886c4893648328833bfbf4c0393ab9