### PR TITLE
Update Event model fields

### DIFF
--- a/docs/AI_Integration_Implementation_Guide.md
+++ b/docs/AI_Integration_Implementation_Guide.md
@@ -600,7 +600,7 @@ class AITurnPipeline:
             type=EventType.NPC_DIALOGUE,
             description=f"{speaker}: {text}",
             turn=self.game_mgr.state.turn_count,
-            metadata={"speaker": speaker, "text": text}
+            meta={"speaker": speaker, "text": text}
         )
         self.game_mgr.state.events_history.append(event)
     
@@ -671,7 +671,7 @@ class AITurnPipeline:
             type=EventType.NARRATIVE,
             description=narrative,
             turn=self.game_mgr.state.turn_count,
-            metadata={"is_narrative": True}
+            meta={"is_narrative": True}
         )
         self.game_mgr.state.events_history.append(event)
 ```

--- a/src/ai/turn_pipeline.py
+++ b/src/ai/turn_pipeline.py
@@ -286,7 +286,7 @@ class AITurnPipeline:
                 type=EventType.NPC_DIALOGUE,
                 description=f"{turn.speaker}: {turn.text}",
                 turn=self.game_mgr.state.current_turn,
-                metadata={
+                meta={
                     "speaker": turn.speaker,
                     "text": turn.text,
                     "emotion": turn.emotion
@@ -545,10 +545,10 @@ class AITurnPipeline:
             if event_turn == current_turn:
                 # 检查是否包含隐藏事件
                 is_hidden = False
-                if hasattr(event, "metadata"):
-                    is_hidden = event.metadata.get("hidden", False)
+                if hasattr(event, "meta"):
+                    is_hidden = event.meta.get("hidden", False)
                 elif isinstance(event, dict):
-                    is_hidden = event.get("metadata", {}).get("hidden", False)
+                    is_hidden = event.get("meta", {}).get("hidden", False)
                 
                 if not is_hidden or include_hidden:
                     turn_events.append(event)
@@ -563,17 +563,17 @@ class AITurnPipeline:
             type=EventType.NARRATIVE,
             description=narrative,
             turn=self.game_mgr.state.current_turn,
-            metadata={"is_narrative": True}
+            meta={"is_narrative": True}
         )
         self.game_mgr.state.events_history.append(event.to_dict())
     
-    def _create_event(self, event_type: EventType, description: str, metadata: Dict[str, Any] = None):
+    def _create_event(self, event_type: EventType, description: str, meta: Dict[str, Any] = None):
         """创建并记录事件"""
         event = Event(
             type=event_type,
             description=description,
             turn=self.game_mgr.state.current_turn,
-            metadata=metadata or {}
+            meta=meta or {}
         )
         self.game_mgr.state.events_history.append(event.to_dict())
         self.game_mgr.log(description)

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -3,5 +3,7 @@
 """
 
 from .npc import NPC   # noqa: F401
-from .rule import Rule           # noqa: F401
-from .event import Event, EventType  # 新增导出  # noqa: F401
+from .rule import Rule  # noqa: F401
+from .event import Event, EventType  # noqa: F401
+
+__all__ = ["NPC", "Rule", "Event", "EventType"]

--- a/src/models/event.py
+++ b/src/models/event.py
@@ -4,9 +4,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 from enum import Enum
 from typing import Any, Dict, Optional
+import uuid
 from datetime import datetime
 
 
@@ -25,19 +26,21 @@ class EventType(str, Enum):
 @dataclass
 class Event:
     """
-    通用事件结构  
-      • `type` : 事件类型  
-      • `description` : 文本描述（⽤于日志 / UI）  
-      • `turn` : 回合号  
-      • `game_time` : 游戏内时间片（morning / night…）  
-      • `data` : 任意附加字段，便于规则或 AI 使用
+    通用事件结构
+      • `id` : 事件唯一标识
+      • `type` : 事件类型
+      • `description` : 文本描述（用于日志 / UI）
+      • `turn` : 回合号
+      • `game_time` : 游戏内时间片（morning / night…）
+      • `meta` : 任意附加字段，便于规则或 AI 使用
     """
 
+    id: str = field(default_factory=lambda: f"evt_{uuid.uuid4().hex[:8]}")
     type: EventType
     description: str
     turn: int
-    game_time: str = ""
-    data: Optional[Dict[str, Any]] = None
+    game_time: Optional[str] = None
+    meta: Optional[Dict[str, Any]] = None
     created_at: datetime = datetime.utcnow()
 
     # ---- 序列化辅助 --------------------------------------------------------
@@ -46,5 +49,4 @@ class Event:
         """转为可 JSON 序列化字典（枚举 → str）"""
         d = asdict(self)
         d["type"] = self.type.value
-        d["created_at"] = self.created_at.isoformat()
         return d


### PR DESCRIPTION
## Summary
- extend `Event` dataclass with `id`, `meta` and optional `game_time`
- adapt event usages to use `meta=` and new fields
- re-export `Event` and `EventType` with `__all__`
- tweak docs for new `meta` argument

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for httpx, pydantic, playwright)*

------
https://chatgpt.com/codex/tasks/task_e_688889d938a88328b6b34a2dca4f1ca1