### PR TITLE
Update rule evaluation prompt API

### DIFF
--- a/src/api/deepseek_client.py
+++ b/src/api/deepseek_client.py
@@ -21,7 +21,7 @@ from src.api.schemas import (
     DialogueTurn, PlannedAction, TurnPlan, NarrativeOut, 
     RuleEvalResult, RuleTrigger, RuleEffect, NPCState, SceneContext
 )
-from src.api.prompts import PromptManager
+from src.api.prompts import PromptManager, RULE_EVAL_SYSTEM
 from src.utils.config import config as global_config
 
 logger = logging.getLogger(__name__)
@@ -375,14 +375,13 @@ class DeepSeekClient:
     ) -> RuleEvalResult:
         """评估自然语言规则"""
         # 构建prompt
-        system_prompt, user_prompt = self.prompt_mgr.build_rule_eval_prompt(
-            rule_nl=rule_nl,
-            rule_count=world_ctx.get("rule_count", 0),
-            avg_fear=world_ctx.get("avg_fear", 50),
-            places=world_ctx.get("places", ["客厅", "卧室", "厨房"]),
+        rule_draft = {"description": rule_nl}
+        user_prompt = self.prompt_mgr.build_rule_eval_prompt(
+            rule_draft,
+            world_ctx,
             difficulty_level=world_ctx.get("difficulty_level"),
-            common_items=world_ctx.get("common_items")
         )
+        system_prompt = RULE_EVAL_SYSTEM
         
         data = {
             "model": self.config.model,

--- a/src/api/prompts.py
+++ b/src/api/prompts.py
@@ -271,28 +271,25 @@ class PromptManager:
     
     def build_rule_eval_prompt(
         self,
-        rule_nl: str,
-        rule_count: int,
-        avg_fear: float,
-        places: List[str],
-        difficulty: str = "normal"
-    ) -> Tuple[str, str]:
-        """
-        构建规则评估的prompt
-        
-        Returns:
-            (system_prompt, user_prompt) 元组
-        """
+        rule_draft: Dict[str, Any],
+        world_ctx: Dict[str, Any],
+        *,
+        difficulty_level: str | None = None,
+    ) -> str:
+        """构建规则评估的用户提示字符串"""
+
         template = self.env.from_string(RULE_EVAL_USER)
         user_prompt = template.render(
-            rule_nl=rule_nl,
-            rule_count=rule_count,
-            avg_fear=round(avg_fear),
-            places=places,
-            difficulty=difficulty
+            rule_nl=rule_draft.get("description", str(rule_draft)),
+            rule_count=world_ctx.get("rule_count", 0),
+            avg_fear=round(world_ctx.get("avg_fear", 50)),
+            places=world_ctx.get("places", []),
+            difficulty=difficulty_level
+            or world_ctx.get("difficulty_level")
+            or world_ctx.get("difficulty", "normal"),
         )
-        
-        return RULE_EVAL_SYSTEM, user_prompt
+
+        return user_prompt
     
     def format_time_chinese(self, time_of_day: str) -> str:
         """将英文时间段转换为中文"""


### PR DESCRIPTION
## Summary
- change `build_rule_eval_prompt` to accept rule_draft and world context
- use new prompt builder in DeepSeek client

## Testing
- `python rulek.py test` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68888b5f40e48328b72755ce7d85f041