### PR TITLE
Restore Config loader

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,24 +1,23 @@
-"""
-API配置数据模型
-"""
-from typing import Optional, Dict, Any
+"""Compatibility configuration helpers used throughout the project."""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from src.utils.config import config as global_config
 
 
 class APIConfig:
-    """API配置类"""
-    
-    def __init__(self, config_dict: dict = None):
+    """Simple container for DeepSeek API settings."""
+
+    def __init__(self, config_dict: Optional[Dict[str, Any]] = None) -> None:
         if config_dict is None:
-            # 使用默认配置
-            from src.utils.config import config
-            deepseek_config = config.get_deepseek_config()
-            self.deepseek_api_key = deepseek_config["api_key"]
-            self.base_url = deepseek_config["base_url"]
-            self.model = deepseek_config["model"]
-            self.timeout = config.get("api", {}).get("timeout", 30)
-            self.max_retries = config.get("api", {}).get("max_retries", 3)
+            ds = global_config.get_deepseek_config()
+            self.deepseek_api_key = ds["api_key"]
+            self.base_url = ds["base_url"]
+            self.model = ds["model"]
+            self.timeout = global_config.get("api", {}).get("timeout", 30)
+            self.max_retries = global_config.get("api", {}).get("max_retries", 3)
         else:
-            # 从字典初始化
             self.deepseek_api_key = config_dict.get("deepseek_api_key", "")
             self.base_url = config_dict.get("base_url", "https://api.deepseek.com/v1")
             self.model = config_dict.get("model", "deepseek-chat")
@@ -26,15 +25,32 @@ class APIConfig:
             self.max_retries = config_dict.get("max_retries", 3)
 
 
-model_config = ConfigDict(
-    """Config类，用于兼容旧代码"""
-    
-    def __init__(self):
-        from src.utils.config import config as global_config
+class Config:
+    """Wrapper around :mod:`src.utils.config` for backward compatibility."""
+
+    def __init__(self) -> None:
         self._config = global_config._config
         self.api = APIConfig()
-    
+
     def get(self, key: str, default: Any = None) -> Any:
-        """获取配置值"""
-        from src.utils.config import config as global_config
         return global_config.get(key, default)
+
+    def get_deepseek_config(self) -> Dict[str, str]:
+        return global_config.get_deepseek_config()
+
+    def is_test_mode(self) -> bool:
+        return global_config.is_test_mode()
+
+    def is_debug_mode(self) -> bool:
+        return global_config.is_debug_mode()
+
+    def get_log_level(self) -> str:
+        return global_config.get_log_level()
+
+    def get_web_config(self) -> Dict[str, Any]:
+        return global_config.get_web_config()
+
+
+config = Config()
+
+__all__ = ["APIConfig", "Config", "config"]

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,166 +1,163 @@
-"""
-配置加载工具
-用于加载环境变量和配置文件
-"""
-import os
+"""Utility module for loading configuration files and environment variables."""
+from __future__ import annotations
+
 import json
-from pathlib import Path
-from typing import Dict, Any, Optional
 import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
 
-model_config = ConfigDict(
-    """配置管理类"""
-    
-    def __init__(self):
-        # 获取项目根目录，确保无论工作目录如何变化都能正确定位
+class Config:
+    """Configuration loader."""
+
+    def __init__(self) -> None:
         self.project_root = Path(__file__).resolve().parents[2]
-        self._config = {}
+        self._config: Dict[str, Any] = {}
         self._load_env()
         self._load_config_files()
-    
-    def _load_env(self):
-        """加载环境变量"""
+
+    # ------------------------------------------------------------------
+    def _load_env(self) -> None:
+        """Load variables from a ``.env`` file if python-dotenv is available."""
         try:
             from dotenv import find_dotenv, load_dotenv
-        except ImportError:
-            logger.warning("python-dotenv 未安装，跳过加载 .env 文件")
+        except Exception:  # pragma: no cover - optional dependency
+            logger.warning("python-dotenv not installed, skipping .env loading")
             return
 
-        # 使用绝对路径查找 .env，兼容不同工作目录
         search_path = self.project_root / ".env"
         dotenv_path = find_dotenv(str(search_path), usecwd=False)
-
         if dotenv_path and Path(dotenv_path).exists():
             load_dotenv(dotenv_path)
-            logger.info(f"环境变量加载成功: {dotenv_path}")
+            logger.info("Loaded environment variables from %s", dotenv_path)
         else:
-            logger.warning("未找到.env文件，使用默认配置")
-    
-    def _load_config_files(self):
-        """加载配置文件"""
+            logger.debug(".env file not found at %s", search_path)
+
+    # ------------------------------------------------------------------
+    def _load_config_files(self) -> None:
+        """Load ``config.json`` and ``deepseek_config.json`` from the project."""
         config_dir = self.project_root / "config"
-        
-        # 加载主配置文件
-        main_config = config_dir / "config.json"
-        if main_config.exists():
+
+        main_cfg = config_dir / "config.json"
+        if main_cfg.exists():
             try:
-                with open(main_config, 'r', encoding='utf-8') as f:
-                    data = json.load(f)
-                    self._config.update(data)
-            except Exception as e:
-                logger.error(f"加载config.json失败: {e}")
-        
-        # 加载DeepSeek配置（如果存在）
-        deepseek_config = config_dir / "deepseek_config.json"
-        if deepseek_config.exists():
+                with open(main_cfg, "r", encoding="utf-8") as fh:
+                    self._config.update(json.load(fh))
+            except Exception as exc:  # pragma: no cover - file reading errors
+                logger.error("Failed to load %s: %s", main_cfg, exc)
+
+        deepseek_cfg = config_dir / "deepseek_config.json"
+        if deepseek_cfg.exists():
             try:
-                with open(deepseek_config, 'r', encoding='utf-8') as f:
-                    data = json.load(f)
-                    self._config['deepseek'] = data
-            except Exception as e:
-                logger.error(f"加载deepseek_config.json失败: {e}")
-    
+                with open(deepseek_cfg, "r", encoding="utf-8") as fh:
+                    self._config["deepseek"] = json.load(fh)
+            except Exception as exc:  # pragma: no cover - file reading errors
+                logger.error("Failed to load %s: %s", deepseek_cfg, exc)
+
+    # ------------------------------------------------------------------
     def get(self, key: str, default: Any = None) -> Any:
-        """获取配置值"""
-        # 先检查环境变量
-        env_value = os.environ.get(key)
-        if env_value is not None:
-            return env_value
-        
-        # 再检查配置字典
+        """Retrieve a configuration value."""
+        env_val = os.environ.get(key)
+        if env_val is not None:
+            return env_val
         return self._config.get(key, default)
-    
+
+    # ------------------------------------------------------------------
     def get_deepseek_config(self) -> Dict[str, str]:
-        """获取DeepSeek API配置"""
+        """Return DeepSeek API configuration settings."""
+        ds_cfg = self._config.get("deepseek", {})
         return {
-            "api_key": self.get("DEEPSEEK_API_KEY", ""),
-            "base_url": self.get("DEEPSEEK_BASE_URL", "https://api.deepseek.com/v1"),
-            "model": self.get("DEEPSEEK_MODEL", "deepseek-chat")
+            "api_key": self.get("DEEPSEEK_API_KEY", ds_cfg.get("api_key", "")),
+            "base_url": self.get(
+                "DEEPSEEK_BASE_URL",
+                ds_cfg.get("base_url", "https://api.deepseek.com/v1"),
+            ),
+            "model": self.get("DEEPSEEK_MODEL", ds_cfg.get("model", "deepseek-chat")),
         }
-    
+
+    # ------------------------------------------------------------------
     def is_test_mode(self) -> bool:
-        """是否处于测试模式"""
-        return self.get("TEST_MODE", "false").lower() == "true"
-    
+        return str(self.get("TEST_MODE", "false")).lower() == "true"
+
     def is_debug_mode(self) -> bool:
-        """是否处于调试模式"""
-        return self.get("GAME_DEBUG", "false").lower() == "true"
-    
+        return str(self.get("GAME_DEBUG", "false")).lower() == "true"
+
     def get_log_level(self) -> str:
-        """获取日志级别"""
-        return self.get("GAME_LOG_LEVEL", "INFO")
-    
+        return str(self.get("GAME_LOG_LEVEL", "INFO"))
+
     def get_web_config(self) -> Dict[str, Any]:
-        """获取Web配置"""
         return {
             "host": self.get("WEB_HOST", "0.0.0.0"),
             "port": int(self.get("WEB_PORT", 8000)),
-            "cors_origins": eval(self.get("WEB_CORS_ORIGINS", '["http://localhost:3000"]'))
+            "cors_origins": eval(
+                self.get("WEB_CORS_ORIGINS", '["http://localhost:3000"]')
+            ),
         }
-    
-    def save_deepseek_config(self, api_key: str, base_url: Optional[str] = None, model: Optional[str] = None):
-        """保存DeepSeek配置到文件"""
+
+    # ------------------------------------------------------------------
+    def save_deepseek_config(
+        self,
+        api_key: str,
+        base_url: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> bool:
+        """Persist DeepSeek configuration to ``deepseek_config.json``."""
         config_dir = self.project_root / "config"
         config_dir.mkdir(exist_ok=True)
-        
-        deepseek_config = config_dir / "deepseek_config.json"
-        
-        config_data = {
+        path = config_dir / "deepseek_config.json"
+        data = {
             "api_key": api_key,
             "base_url": base_url or "https://api.deepseek.com/v1",
-            "model": model or "deepseek-chat"
+            "model": model or "deepseek-chat",
         }
-        
         try:
-            with open(deepseek_config, 'w', encoding='utf-8') as f:
-                json.dump(config_data, f, indent=2, ensure_ascii=False)
-            logger.info("DeepSeek配置已保存")
+            with open(path, "w", encoding="utf-8") as fh:
+                json.dump(data, fh, indent=2, ensure_ascii=False)
+            self._config["deepseek"] = data
+            logger.info("DeepSeek configuration saved to %s", path)
             return True
-        except Exception as e:
-            logger.error(f"保存配置失败: {e}")
+        except Exception as exc:  # pragma: no cover - file writing errors
+            logger.error("Failed to save deepseek config: %s", exc)
             return False
 
 
-# 全局配置实例
+# ---------------------------------------------------------------------------
+# Global helpers
 config = Config()
 
 
 def load_config(path: str | None = None) -> Config:
-    """从指定路径加载JSON配置并更新全局配置对象"""
+    """Load an extra JSON configuration file into the global ``config`` object."""
     if path:
         cfg_path = Path(path)
         if cfg_path.exists():
             try:
-                with open(cfg_path, "r", encoding="utf-8") as f:
-                    data = json.load(f)
-                    if isinstance(data, dict):
-                        config._config.update(data)
-                        logger.info(f"已加载自定义配置: {path}")
-                    else:
-                        logger.warning(f"配置文件{path}不是有效的JSON对象")
-            except Exception as e:
-                logger.error(f"加载自定义配置失败: {e}")
+                with open(cfg_path, "r", encoding="utf-8") as fh:
+                    data = json.load(fh)
+                if isinstance(data, dict):
+                    config._config.update(data)
+                    logger.info("Loaded custom config from %s", path)
+                else:
+                    logger.warning("Config file %s does not contain a JSON object", path)
+            except Exception as exc:  # pragma: no cover - file reading errors
+                logger.error("Failed to load custom config: %s", exc)
         else:
-            logger.error(f"配置文件不存在: {path}")
+            logger.error("Config file not found: %s", path)
     return config
 
 
-# 便捷函数
 def get_deepseek_config() -> Dict[str, str]:
-    """获取DeepSeek配置"""
     return config.get_deepseek_config()
 
 
 def is_test_mode() -> bool:
-    """是否处于测试模式"""
     return config.is_test_mode()
 
 
 def is_debug_mode() -> bool:
-    """是否处于调试模式"""
     return config.is_debug_mode()
 
 

--- a/tests/detection/test_config.py
+++ b/tests/detection/test_config.py
@@ -1,0 +1,17 @@
+import json
+from src.utils.config import Config, load_config, config
+
+
+def test_load_config(tmp_path):
+    # ensure load_config returns Config instance
+    cfg_file = tmp_path / "extra.json"
+    cfg_file.write_text(json.dumps({"sample_key": "sample_value"}))
+
+    cfg = load_config(str(cfg_file))
+    assert isinstance(cfg, Config)
+    assert cfg.get("sample_key") == "sample_value"
+
+
+def test_global_config_exposes_helpers():
+    assert isinstance(config.get_deepseek_config(), dict)
+    assert hasattr(config, "is_test_mode")


### PR DESCRIPTION
## Summary
- rewrite `src/utils.config` with a working `Config` class
- rebuild `src/config` to wrap the global loader
- add regression tests for `load_config`

## Testing
- `pytest tests/detection/test_config.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_6889bee5d0d883289abf0250f07c199b