### PR TITLE
Add DEV_MODE config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,4 @@ REDIS_URL=redis://localhost:6379
 
 # Testing
 TEST_MODE=false
+DEV_MODE=true  # 在运行 rulek.py --dev 时启用开发模式


### PR DESCRIPTION
## Summary
- demo development mode variable in `.env.example`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6889c57f05888328b83dffc9d5f01ef3