### PR TITLE
Update test setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,15 @@ RuleK/
 
 ## 🧪 测试
 
+在运行测试前，请先安装依赖并准备 Playwright：
+
+```bash
+pip install -r requirements.txt
+python -m playwright install  # 可选：安装浏览器
+```
+
+完成以上步骤后即可执行测试：
+
 ```bash
 # 运行所有测试
 python rulek.py test


### PR DESCRIPTION
## Summary
- document how to install Python dependencies and playwright before running tests

## Testing
- `python rulek.py test` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6889c6ae89cc832884bb7774d84f71f9