### PR TITLE
Fix fallback types in rule evaluation

### DIFF
--- a/src/api/deepseek_client.py
+++ b/src/api/deepseek_client.py
@@ -418,8 +418,8 @@ class DeepSeekClient:
             # 返回默认评估
             return RuleEvalResult(
                 name="未知规则",
-                trigger=RuleTrigger(type="unknown", conditions=[]),
-                effect=RuleEffect(type="unknown", params={}),
+                trigger=RuleTrigger(type="event", conditions=[]),
+                effect=RuleEffect(type="custom", params={}),
                 cost=100,
                 difficulty=5,
                 loopholes=["规则解析失败"],


### PR DESCRIPTION
## Summary
- fix `evaluate_rule_nl` fallback values so `RuleTrigger` and `RuleEffect` use valid types

## Testing
- `python scripts/dev_tools.py check` *(fails: type check & tests)*

------
https://chatgpt.com/codex/tasks/task_e_6889ea43c99483288f42b210d15577e3