### PR TITLE
fix narrator game_state access

### DIFF
--- a/src/core/narrator.py
+++ b/src/core/narrator.py
@@ -46,31 +46,33 @@ class Narrator:
             "npc_action": [
                 "{npc}小心翼翼地{action}，空气中弥漫着不祥的气息。",
                 "在昏暗的{location}中，{npc}{action}，似乎有什么在暗中窥视。",
-                "{npc}的身影在{location}中{action}，留下了一串不安的回响。"
+                "{npc}的身影在{location}中{action}，留下了一串不安的回响。",
             ],
             "rule_triggered": [
                 "规则的力量开始显现，{rule}被触发了，恐怖笼罩着整个空间。",
                 "违背了禁忌，{rule}的诅咒降临，无人能够逃脱。",
-                "古老的规则被打破，{rule}带来了不可名状的恐惧。"
+                "古老的规则被打破，{rule}带来了不可名状的恐惧。",
             ],
             "dialogue": [
                 "在压抑的氛围中，{participants}交换着不安的眼神。",
                 "{participants}的对话在空荡的房间里回响，每个字都充满了恐惧。",
-                "颤抖的声音中，{participants}试图寻找一丝希望。"
+                "颤抖的声音中，{participants}试图寻找一丝希望。",
             ],
             "time_change": {
                 "morning": "晨光透过破碎的窗户，却无法驱散笼罩的阴霾。",
                 "afternoon": "午后的阳光显得格外苍白，仿佛被什么吸走了生机。",
                 "evening": "夜幕降临，黑暗中潜伏着未知的恐怖。",
-                "night": "深夜的寂静被诡异的声响打破，恐惧在每个角落蔓延。"
-            }
+                "night": "深夜的寂静被诡异的声响打破，恐惧在每个角落蔓延。",
+            },
         }
 
     def set_style(self, style: NarrativeStyle) -> None:
         """Set narrative style (currently unused)."""
         self.style = style
-    
-    async def generate_narrative(self, events: List[Dict[str, Any]], game_state: Any) -> str:
+
+    async def generate_narrative(
+        self, events: List[Dict[str, Any]], game_state: Any
+    ) -> str:
         """生成叙事文本"""
         if self.deepseek_client:
             # 使用AI生成叙事
@@ -84,66 +86,75 @@ class Narrator:
                     elif event_type == "rule_triggered":
                         desc = f"规则'{event.get('rule', '未知规则')}'被触发，{event.get('result', {}).get('description', '产生了恐怖的后果')}"
                     elif event_type == "dialogue":
-                        participants = event.get('participants', [])
+                        participants = event.get("participants", [])
                         desc = f"{' 和 '.join(participants)}进行了一段对话"
                     else:
-                        desc = event.get('description', '发生了一些事情')
+                        desc = event.get("description", "发生了一些事情")
                     event_descriptions.append(desc)
-                
+
                 # 调用AI生成叙事
+                time_of_day = (
+                    game_state.get("time_of_day")
+                    if isinstance(game_state, dict)
+                    else getattr(game_state, "time_of_day", None)
+                )
                 narrative = await self.deepseek_client.generate_narrative_text(
                     events=event_descriptions,
-                    time_of_day=game_state.time_of_day,
+                    time_of_day=time_of_day,
                     min_len=200,
                 )
                 return narrative
             except Exception:
                 # 如果AI失败，使用模板生成
                 pass
-        
+
         # 使用模板生成叙事
         narrative_parts = []
-        
+
         # 添加时间描述
+        time_of_day = (
+            game_state.get("time_of_day")
+            if isinstance(game_state, dict)
+            else getattr(game_state, "time_of_day", None)
+        )
         time_desc = self.narrative_templates["time_change"].get(
-            game_state.time_of_day,
-            "时间在恐惧中流逝。"
+            time_of_day, "时间在恐惧中流逝。"
         )
         narrative_parts.append(time_desc)
-        
+
         # 处理每个事件
         for event in events[-3:]:  # 只处理最近3个事件
             event_type = event.get("type", "unknown")
-            
+
             if event_type == "npc_action":
                 template = random.choice(self.narrative_templates["npc_action"])
                 text = template.format(
                     npc=event.get("npc", "某人"),
                     action=event.get("action", "移动"),
-                    location=event.get("location", "未知地点")
+                    location=event.get("location", "未知地点"),
                 )
                 narrative_parts.append(text)
-                
+
             elif event_type == "rule_triggered":
                 template = random.choice(self.narrative_templates["rule_triggered"])
-                text = template.format(
-                    rule=event.get("rule", "未知规则")
-                )
+                text = template.format(rule=event.get("rule", "未知规则"))
                 narrative_parts.append(text)
-                
+
             elif event_type == "dialogue":
                 template = random.choice(self.narrative_templates["dialogue"])
                 participants = event.get("participants", ["某些人"])
-                text = template.format(
-                    participants="和".join(participants)
-                )
+                text = template.format(participants="和".join(participants))
                 narrative_parts.append(text)
-        
+
         # 组合叙事
         narrative = " ".join(narrative_parts)
-        
+
         # 添加氛围描述
-        if game_state.fear_points > 500:
+        if (
+            game_state.get("fear_points", 0)
+            if isinstance(game_state, dict)
+            else getattr(game_state, "fear_points", 0)
+        ) > 500:
             narrative += " 恐惧已经达到了临界点，整个空间都在颤抖。"
 
         return narrative
@@ -151,5 +162,10 @@ class Narrator:
     async def narrate_turn(self, events: List[GameEvent], game_state: Dict[str, Any]):
         """Generate a simple chapter object for a turn."""
         text = await self.generate_narrative([e.__dict__ for e in events], game_state)
-        title = f"Turn {game_state.get('current_turn', 0)}" if game_state else "Narrative"
+        current_turn = (
+            game_state.get("current_turn", 0)
+            if isinstance(game_state, dict)
+            else getattr(game_state, "current_turn", 0)
+        )
+        title = f"Turn {current_turn}" if game_state else "Narrative"
         return type("Chapter", (), {"title": title, "content": text})()

--- a/tests/unit/test_sprint2.py
+++ b/tests/unit/test_sprint2.py
@@ -3,16 +3,16 @@
 Sprint 2 功能测试 - 测试AI对话和叙事系统
 """
 import pytest
-import asyncio
 import sys
 import os
 
 # 添加项目根目录到Python路径
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '../..'))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "../.."))
 
 from src.api.deepseek_client import DeepSeekClient, APIConfig
 from src.core.dialogue_system import DialogueSystem
-from src.core.narrator import Narrator, GameEvent, EventSeverity, NarrativeStyle
+from src.core.dialogue_system import DialogueContext, DialogueType
+from src.core.narrator import Narrator, GameEvent, EventSeverity
 from src.models.npc import generate_random_npc
 
 
@@ -22,45 +22,41 @@ async def test_api_client():
     # 创建Mock模式客户端
     config = APIConfig(mock_mode=True)
     client = DeepSeekClient(config)
-    
+
     # 测试对话生成
     npc_states = [
         {"name": "小明", "fear": 60, "sanity": 70, "status": "frightened"},
-        {"name": "小红", "fear": 40, "sanity": 85, "status": "normal"}
+        {"name": "小红", "fear": 40, "sanity": 85, "status": "normal"},
     ]
-    
-    scene_context = {
-        "location": "废弃浴室",
-        "time": "午夜",
-        "recent_events": "刚才镜子里出现了诡异的影子"
-    }
-    
+
+    scene_context = {"location": "废弃浴室", "time": "午夜", "recent_events": "刚才镜子里出现了诡异的影子"}
+
     dialogues = await client.generate_dialogue(npc_states, scene_context)
     assert isinstance(dialogues, list)
     assert len(dialogues) > 0
-    assert all('speaker' in d and 'text' in d for d in dialogues)
-    
+    assert all("speaker" in d and "text" in d for d in dialogues)
+
     # 测试规则评估
     rule_draft = {
         "name": "回头杀",
         "trigger": {"action": "turn_around", "conditions": ["alone"]},
-        "effect": {"type": "instant_death"}
+        "effect": {"type": "instant_death"},
     }
-    
+
     evaluation = await client.evaluate_rule(rule_draft, {"rule_count": 3})
-    assert 'cost_estimate' in evaluation
-    assert 'difficulty' in evaluation
-    
+    assert "cost_estimate" in evaluation
+    assert "difficulty" in evaluation
+
     # 测试叙事生成
     events = [
         {"type": "rule_triggered", "description": "小明触发了镜中恶魔规则"},
-        {"type": "npc_death", "description": "小明被拖入镜中消失"}
+        {"type": "npc_death", "description": "小明被拖入镜中消失"},
     ]
-    
+
     narration = await client.narrate_events(events)
     assert isinstance(narration, str)
     assert len(narration) > 0
-    
+
     await client.close()
 
 
@@ -71,34 +67,34 @@ async def test_dialogue_system():
     npcs = [
         generate_random_npc("测试员A"),
         generate_random_npc("测试员B"),
-        generate_random_npc("测试员C")
+        generate_random_npc("测试员C"),
     ]
-    
+
     # 设置一些状态
     npcs[0].add_fear(70)
     npcs[1].memory.remember_rule("mirror_death")
-    
+
     # 创建对话系统
     dialogue_system = DialogueSystem()
-    
+
     # 测试早间对话
     context = DialogueContext(
         location="测试地点",
         time="测试时间",
         participants=[npc.id for npc in npcs],
         recent_events=[],
-        mood="tense"
+        mood="tense",
     )
-    
+
     entry = await dialogue_system.generate_dialogue_round(
         npcs, context, DialogueType.MORNING, 1
     )
-    
+
     assert entry is not None
     assert len(entry.dialogues) > 0
     assert entry.turn == 1
     assert entry.dialogue_type == DialogueType.MORNING
-    
+
     await dialogue_system.api_client.close()
 
 
@@ -106,7 +102,7 @@ async def test_dialogue_system():
 async def test_narrator():
     """测试叙事生成器"""
     narrator = Narrator()
-    
+
     # 创建测试事件
     events = [
         GameEvent(
@@ -114,31 +110,26 @@ async def test_narrator():
             severity=EventSeverity.MODERATE,
             actors=["测试员A"],
             location="测试浴室",
-            details={"item": "神秘的日记本"}
+            details={"item": "神秘的日记本"},
         ),
         GameEvent(
             event_type="npc_death",
             severity=EventSeverity.CRITICAL,
             actors=["测试员B"],
             location="测试浴室",
-            details={"victim": "测试员B", "cause": "未知诅咒"}
-        )
+            details={"victim": "测试员B", "cause": "未知诅咒"},
+        ),
     ]
-    
+
     chapter = await narrator.narrate_turn(
-        events,
-        {
-            "current_turn": 1,
-            "time_of_day": "night",
-            "average_fear": 65
-        }
+        events, {"current_turn": 1, "time_of_day": "night", "average_fear": 65}
     )
-    
+
     assert chapter is not None
-    assert hasattr(chapter, 'title')
-    assert hasattr(chapter, 'content')
+    assert hasattr(chapter, "title")
+    assert hasattr(chapter, "content")
     assert len(chapter.content) > 0
-    
+
     await narrator.api_client.close()
 
 
@@ -149,68 +140,64 @@ async def test_integration():
     api_client = DeepSeekClient(APIConfig(mock_mode=True))
     dialogue_system = DialogueSystem(api_client)
     narrator = Narrator(api_client)
-    
+
     # 创建NPC
     npcs = [
         generate_random_npc("张三"),
         generate_random_npc("李四"),
-        generate_random_npc("王五")
+        generate_random_npc("王五"),
     ]
-    
+
     # 第一回合：早间对话
     context = DialogueContext(
-        location="客厅",
-        time="早晨",
-        participants=[npc.id for npc in npcs],
-        mood="nervous"
+        location="客厅", time="早晨", participants=[npc.id for npc in npcs], mood="nervous"
     )
-    
+
     dialogue_entry = await dialogue_system.generate_dialogue_round(
         npcs, context, DialogueType.MORNING, 1
     )
-    
+
     assert dialogue_entry is not None
     assert len(dialogue_entry.dialogues) > 0
-    
+
     # 发生事件
     npcs[0].memory.remember_rule("mirror_death")
     npcs[0].add_fear(30)
-    
+
     discovery_event = GameEvent(
         event_type="discovery",
         severity=EventSeverity.MAJOR,
         actors=["张三"],
         location="浴室",
-        details={"item": "写着血字的镜子"}
+        details={"item": "写着血字的镜子"},
     )
-    
+
     # 生成发现对话
     context.discovered_clues = ["午夜不要照镜子"]
     discovery_dialogue = await dialogue_system.generate_dialogue_round(
         npcs, context, DialogueType.DISCOVERY, 2
     )
-    
+
     assert discovery_dialogue is not None
     assert discovery_dialogue.dialogue_type == DialogueType.DISCOVERY
-    
+
     # 死亡事件
     death_event = GameEvent(
         event_type="npc_death",
         severity=EventSeverity.CRITICAL,
         actors=["李四"],
         location="浴室",
-        details={"victim": "李四", "cause": "镜中恶魔"}
+        details={"victim": "李四", "cause": "镜中恶魔"},
     )
-    
+
     # 生成叙述
     chapter = await narrator.narrate_turn(
-        [discovery_event, death_event],
-        {"current_turn": 3, "time_of_day": "midnight"}
+        [discovery_event, death_event], {"current_turn": 3, "time_of_day": "midnight"}
     )
-    
+
     assert chapter is not None
     assert len(chapter.content) > 0
-    
+
     await api_client.close()
 
 


### PR DESCRIPTION
## Summary
- add missing imports for DialogueContext and DialogueType
- support passing dictionaries to `generate_narrative`

## Testing
- `python scripts/dev_tools.py check` *(fails: 4 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6889eb8da82483288986382dfc455a89