### PR TITLE
Add frontend dependency install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ python rulek.py web
 cd web/frontend && npm run dev
 ```
 
+### 安装前端依赖
+
+如需单独调试或构建前端，请在 `web/frontend` 目录执行：
+
+```bash
+npm install
+```
+
 访问 http://localhost:5173 开始游戏！
 
 ### 方式三：Docker


### PR DESCRIPTION
## Summary
- run npm install in `web/frontend`
- document frontend dependency installation in README

## Testing
- `python scripts/dev_tools.py check` *(fails: mypy errors and failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6889f64d37cc83288f34ce51ed4fd310