### PR TITLE
Enhance dependency checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ pip install -r requirements.txt
 python -m playwright install  # 可选：安装浏览器
 ```
 
+`scripts/dev_tools.py check` 命令同样依赖上述包，请在运行该脚本前先执行 `pip install -r requirements.txt`。
+
 完成以上步骤后即可执行测试：
 
 ```bash

--- a/scripts/dev_tools.py
+++ b/scripts/dev_tools.py
@@ -183,6 +183,17 @@ def check_dependencies():
     else:
         print("❌ Python依赖有问题:")
         print(result.stdout)
+
+    # 检查关键依赖是否存在
+    import importlib.util
+
+    required_packages = ["pydantic", "httpx"]
+    missing = [pkg for pkg in required_packages if importlib.util.find_spec(pkg) is None]
+    if missing:
+        print(f"⚠️  缺少必要依赖: {', '.join(missing)}")
+        print("   请运行: pip install -r requirements.txt")
+    else:
+        print("✅ 关键依赖已安装")
     
     # 检查前端依赖
     print("\n前端依赖:")


### PR DESCRIPTION
## Summary
- warn when key Python packages are missing in `scripts/dev_tools.py`
- document running `pip install -r requirements.txt` before using `scripts/dev_tools.py check`

## Testing
- `python scripts/dev_tools.py check` *(fails: tests and mypy issues)*

------
https://chatgpt.com/codex/tasks/task_e_688a0773f7048328b0e413c16a2c3aae