### PR TITLE
Fix dialogue system and narrator default API client

### DIFF
--- a/src/core/dialogue_system.py
+++ b/src/core/dialogue_system.py
@@ -3,6 +3,8 @@
 生成NPC之间的对话
 """
 from typing import List, Dict, Any, Optional
+
+from src.api.deepseek_client import APIConfig, DeepSeekClient
 import random
 from enum import Enum
 from dataclasses import dataclass
@@ -47,8 +49,11 @@ class DialogueSystem:
     """对话系统"""
     
     def __init__(self, deepseek_client=None):
-        self.deepseek_client = deepseek_client
-        self.api_client = deepseek_client  # 兼容旧代码
+        """Initialize dialogue system with an optional DeepSeek client."""
+        self.deepseek_client = deepseek_client or DeepSeekClient(
+            APIConfig(mock_mode=True)
+        )
+        self.api_client = self.deepseek_client  # backward compatibility
         self.dialogue_templates = {
             "fear": [
                 "{npc1}: 你有没有感觉到...这里不太对劲？",

--- a/src/core/narrator.py
+++ b/src/core/narrator.py
@@ -3,6 +3,8 @@
 生成恐怖氛围的游戏叙事
 """
 from typing import List, Dict, Any
+
+from src.api.deepseek_client import APIConfig, DeepSeekClient
 from enum import Enum
 from dataclasses import dataclass
 import random
@@ -40,7 +42,11 @@ class Narrator:
     """叙事生成器"""
 
     def __init__(self, deepseek_client=None):
-        self.deepseek_client = deepseek_client
+        """Initialize the narrator with an optional DeepSeek client."""
+        self.deepseek_client = deepseek_client or DeepSeekClient(
+            APIConfig(mock_mode=True)
+        )
+        self.api_client = self.deepseek_client
         self.style: NarrativeStyle = NarrativeStyle.DEFAULT
         self.narrative_templates = {
             "npc_action": [


### PR DESCRIPTION
## Summary
- ensure `DialogueSystem` and `Narrator` create a mock DeepSeek client when not provided
- expose the client via `api_client` for backward compatibility

## Testing
- `python scripts/dev_tools.py check`

------
https://chatgpt.com/codex/tasks/task_e_688a0a82290c83289768c15f1fead34a