### PR TITLE
Fix mypy plugin setup and type errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,11 @@ exclude_lines = [
     "raise NotImplementedError",
     "if __name__ == .__main__.:",
 ]
+
+[tool.mypy]
+plugins = ["pydantic.mypy"]
+ignore_missing_imports = true
+
+[tool.pydantic-mypy]
+init_typed = true
+warn_untyped_fields = true

--- a/src/ai/turn_pipeline.py
+++ b/src/ai/turn_pipeline.py
@@ -309,9 +309,10 @@ class AITurnPipeline:
                 "calm": "😐",
                 "panic": "😱",
                 "suspicious": "🤨",
-                "angry": "😠"
+                "angry": "😠",
             }
-            emoji = emotion_emoji.get(turn.emotion, "💬")
+            key = turn.emotion or "calm"
+            emoji = emotion_emoji.get(key, "💬")
             self.game_mgr.log(f"{emoji} {turn.speaker}: {turn.text}")
     
     async def _process_actions(self, actions: List[PlannedAction]):
@@ -582,7 +583,9 @@ class AITurnPipeline:
         )
         state.events_history.append(event.to_dict())
     
-    def _create_event(self, event_type: EventType, description: str, meta: Dict[str, Any] = None):
+    def _create_event(
+        self, event_type: EventType, description: str, meta: Optional[Dict[str, Any]] = None
+    ):
         """创建并记录事件"""
         if self.game_mgr.state is None:
             raise RuntimeError("游戏状态未初始化")

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -224,7 +224,10 @@ class BatchRequest(BaseModel):
 # ========== 工具函数 ==========
 
 
-def create_error_response(error_msg: str, error_type: str = "unknown") -> AIError:
+ErrorType = Literal["parse", "validation", "api", "timeout", "unknown"]
+
+
+def create_error_response(error_msg: str, error_type: ErrorType = "unknown") -> AIError:
     """创建标准错误响应"""
     suggestions = {
         "parse": "请检查输入格式是否正确",

--- a/src/core/dialogue_system.py
+++ b/src/core/dialogue_system.py
@@ -42,7 +42,7 @@ class DialogueEntry:
     def __init__(self, turn: int, dialogue_type: DialogueType):
         self.turn = turn
         self.dialogue_type = dialogue_type
-        self.dialogues: List[str] = []
+        self.dialogues: List[dict[str, str]] = []
 
 
 class DialogueSystem:

--- a/src/core/game_state.py
+++ b/src/core/game_state.py
@@ -2,7 +2,7 @@
 游戏状态管理器
 负责管理整个游戏的状态，包括积分、规则、NPC等
 """
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Literal
 from datetime import datetime
 from dataclasses import dataclass, field
 import json
@@ -29,7 +29,7 @@ class GameState:
     
     # 游戏阶段
     phase: GamePhase = GamePhase.SETUP
-    time_of_day: str = "morning"  # morning, afternoon, evening, night
+    time_of_day: Literal["morning", "afternoon", "evening", "night"] = "morning"  # daytime
     mode: GameMode = GameMode.BACKSTAGE
     
     # 统计
@@ -101,7 +101,7 @@ class GameState:
 class GameStateManager:
     """游戏状态管理器"""
     
-    def __init__(self, save_dir: str = "data/saves", config: Dict[str, Any] = None):
+    def __init__(self, save_dir: str = "data/saves", config: Optional[Dict[str, Any]] = None):
         self.save_dir = Path(save_dir)
         self.save_dir.mkdir(parents=True, exist_ok=True)
         
@@ -117,7 +117,7 @@ class GameStateManager:
         self.ai_pipeline: Optional['AITurnPipeline'] = None
         
         # 事件监听器
-        self.event_listeners = {
+        self.event_listeners: Dict[str, List[Any]] = {
             "turn_start": [],
             "turn_end": [],
             "rule_triggered": [],
@@ -125,7 +125,7 @@ class GameStateManager:
             "fear_gained": []
         }
         
-    def new_game(self, game_id: Optional[str] = None, config: Dict[str, Any] = None) -> GameState:
+    def new_game(self, game_id: Optional[str] = None, config: Optional[Dict[str, Any]] = None) -> GameState:
         """开始新游戏
 
         Args:
@@ -208,7 +208,7 @@ class GameStateManager:
                     result[key] = value
             return result
         else:
-            return str(rule)  # 最后的选择：转换为字符串
+            return {"raw": str(rule)}  # 最后的选择：转换为字符串
         
     def load_game(self, game_id: str) -> bool:
         """加载游戏存档"""

--- a/src/models/event.py
+++ b/src/models/event.py
@@ -22,6 +22,8 @@ class EventType(str, Enum):
     SYSTEM       = "system"                # 系统提示、存档等
     NARRATION    = "narration"             # AI 生成叙事
     NARRATIVE    = "narrative"             # AI 生成叙事（别名）
+    ITEM_FOUND   = "item_found"            # 发现物品
+    CLUE_FOUND   = "clue_found"            # 发现线索
 
 
 @dataclass

--- a/src/models/npc.py
+++ b/src/models/npc.py
@@ -119,6 +119,11 @@ class NPC(BaseModel):
     
     # 行为修正
     action_modifiers: Dict[str, float] = Field(default_factory=dict)
+
+    @property
+    def is_alive(self) -> bool:
+        """NPC是否存活"""
+        return self.status != NPCStatus.DEAD
     
     def update_status(self):
         """根据当前状态更新NPC状态"""

--- a/src/models/npc_manager.py
+++ b/src/models/npc_manager.py
@@ -26,7 +26,8 @@ class NPCManager:
                 self.name_index += 1
             else:
                 name = f"NPC_{len(self.npcs) + 1}"
-        
+
+        assert name is not None
         npc = NPC(name=name, **kwargs)
         self.npcs[npc.id] = npc
         return npc


### PR DESCRIPTION
## Summary
- enable pydantic mypy plugin via pyproject
- update API helpers with Literal types
- adjust dialogue system entry structure
- add missing event types
- provide NPC `is_alive` property and safe creation
- annotate GameState and GameStateManager fields
- update turn pipeline and event creation helpers

## Testing
- `python scripts/dev_tools.py format`
- `python scripts/dev_tools.py check` *(fails: mypy errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_688a0dc3e7cc832884036273e31246b5