### PR TITLE
实现数据库迁移命令

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,15 @@ python rulek.py test unit
 python rulek.py test integration
 ```
 
+### 数据库迁移
+
+安装 Alembic 后可执行：
+
+```bash
+pip install alembic              # 如未安装
+python scripts/dev_tools.py migrate
+```
+
 ## 🔧 配置
 
 ### 环境变量

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,9 @@ fastapi==0.104.1
 uvicorn[standard]==0.24.0
 websockets==12.0
 
+# 数据库迁移
+alembic==1.16.4
+
 # 注意事项：
 # 1. Python 3.7+ 必需（使用了asyncio）
 # 2. 大部分功能使用Python标准库

--- a/scripts/dev_tools.py
+++ b/scripts/dev_tools.py
@@ -139,9 +139,32 @@ def generate_api_docs():
 def create_migration():
     """创建数据迁移脚本"""
     print("🔄 创建数据迁移...")
-    
-    # TODO: 实现数据迁移功能
-    print("⚠️  数据迁移功能开发中...")
+
+    import importlib.util
+
+    if importlib.util.find_spec("alembic") is None:
+        print("❌ 未安装 Alembic，请运行: pip install alembic")
+        return False
+
+    alembic_ini = project_root / "alembic.ini"
+    try:
+        if not alembic_ini.exists():
+            subprocess.run(["alembic", "init", "migrations"], check=True, cwd=project_root)
+            print("✅ Alembic 已初始化")
+
+        message = input("迁移描述: ").strip() or "auto migration"
+
+        subprocess.run(
+            ["alembic", "revision", "--autogenerate", "-m", message],
+            check=True,
+            cwd=project_root,
+        )
+        subprocess.run(["alembic", "upgrade", "head"], check=True, cwd=project_root)
+        print("✅ 迁移脚本已创建并应用")
+    except subprocess.CalledProcessError:
+        print("❌ 数据迁移失败")
+        return False
+
     return True
 
 


### PR DESCRIPTION
## Summary
- 实现 `create_migration`，使用 Alembic 生成并应用迁移脚本
- 在 `requirements.txt` 中添加 Alembic 依赖
- 更新 README，说明如何运行数据库迁移

## Testing
- `python scripts/dev_tools.py check`

------
https://chatgpt.com/codex/tasks/task_e_688b44c767c8832899232c7bca907510