### PR TITLE
feat(api): handle cache write errors

### DIFF
--- a/scripts/fix/fix_cache_errors.sh
+++ b/scripts/fix/fix_cache_errors.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 清理缓存写入失败时生成的 .error 标记文件
+find data/cache/api -name '*.error' -delete
+

--- a/tests/unit/test_response_cache.py
+++ b/tests/unit/test_response_cache.py
@@ -1,0 +1,35 @@
+import builtins
+from pathlib import Path
+
+from src.api.deepseek_client import ResponseCache
+
+
+def test_set_creates_error_file_on_failure(tmp_path, monkeypatch):
+    cache = ResponseCache(tmp_path)
+
+    original_open = builtins.open
+
+    def fake_open(path, mode="r", *args, **kwargs):
+        if isinstance(path, (str, Path)) and str(path).endswith(".json") and "w" in mode:
+            raise OSError("disk error")
+        return original_open(path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+    cache.set("p", {"k": "v"}, {"result": True})
+
+    error_files = list(tmp_path.glob("*.error"))
+    assert len(error_files) == 1
+
+
+def test_get_removes_error_file(tmp_path):
+    cache = ResponseCache(tmp_path)
+    key = cache._generate_key("p", {"k": "v"})
+    error_file = tmp_path / f"{key}.error"
+    error_file.touch()
+
+    result = cache.get("p", {"k": "v"})
+
+    assert result is None
+    assert not error_file.exists()
+


### PR DESCRIPTION
## Summary
- mark cache write errors with `.error` files and ignore them when reading
- add cleanup script for cache error markers
- cover ResponseCache error handling with unit tests

## Testing
- `pytest tests/unit/test_response_cache.py -q`
- `make test` *(fails: requests.exceptions.ConnectionError; playwright._impl._api_types.Error)*

------
https://chatgpt.com/codex/tasks/task_e_68a10f1410dc8328a976675d76ae1320