### PR TITLE
test(web): provide shared event loop fixture

### DIFF
--- a/tests/web/__init__.py
+++ b/tests/web/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytestmark = pytest.mark.asyncio

--- a/tests/web/conftest.py
+++ b/tests/web/conftest.py
@@ -1,0 +1,10 @@
+import asyncio
+import pytest
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    """Create a session-scoped event loop for web tests."""
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()


### PR DESCRIPTION
## Summary
- add session-scoped `event_loop` fixture for web tests
- mark web tests with `pytest.mark.asyncio`

## Testing
- `pytest tests/web -q` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium-1084/chrome-linux/chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68a1152254e08328a171d379055975b5