### PR TITLE
style(config): shorten long lines

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -16,10 +16,14 @@ class APIConfig:
             self.base_url = ds["base_url"]
             self.model = ds["model"]
             self.timeout = global_config.get("api", {}).get("timeout", 30)
-            self.max_retries = global_config.get("api", {}).get("max_retries", 3)
+            self.max_retries = global_config.get("api", {}).get(
+                "max_retries", 3
+            )
         else:
             self.deepseek_api_key = config_dict.get("deepseek_api_key", "")
-            self.base_url = config_dict.get("base_url", "https://api.deepseek.com/v1")
+            self.base_url = config_dict.get(
+                "base_url", "https://api.deepseek.com/v1"
+            )
             self.model = config_dict.get("model", "deepseek-chat")
             self.timeout = config_dict.get("timeout", 30)
             self.max_retries = config_dict.get("max_retries", 3)


### PR DESCRIPTION
## Summary
- 格式化配置模块中的长行，使其符合 PEP 8

## Testing
- `flake8 src/config.py`
- `pytest` *(1 失败, 8 错误: 缺少 Playwright 浏览器与本地 API)*

------
https://chatgpt.com/codex/tasks/task_e_68a11bd305d08328859e199de8ff61ef