### PR TITLE
fix(main): setup unified logging on startup

### DIFF
--- a/docs/UNIFIED_ENTRY.md
+++ b/docs/UNIFIED_ENTRY.md
@@ -64,6 +64,8 @@
 
 ## 📋 使用方法
 
+运行入口命令时会自动生成 `artifacts/runtime_extract.log` 用于记录运行日志。
+
 ### 交互式菜单（新手推荐）
 ```bash
 python rulek.py

--- a/rulek.py
+++ b/rulek.py
@@ -16,6 +16,8 @@ import signal
 from pathlib import Path
 from typing import List, Optional, Dict, Callable
 
+from src.utils.logger import setup_logging
+
 # 项目根目录
 PROJECT_ROOT = Path(__file__).parent
 sys.path.insert(0, str(PROJECT_ROOT))
@@ -507,6 +509,9 @@ signal.signal(signal.SIGTERM, handle_signal)
 
 def main():
     """主函数"""
+    logger = setup_logging()
+    logger.info("RuleK unified entry started")
+
     # 命令映射
     commands = {
         "start": start_full_game,


### PR DESCRIPTION
## Summary
- initialize unified logging in `rulek.py` so a runtime log is produced on startup
- document that running the unified entry creates `artifacts/runtime_extract.log`

## Testing
- `python scripts/dev_tools.py check` *(fails: E722 in src/api/schemas.py; frontend deps missing)*
- `python rulek.py help`


------
https://chatgpt.com/codex/tasks/task_e_68aa773e7cc4832880d7d362f924847a