### PR TITLE
fix(deepseek): unify logger namespace

### DIFF
--- a/src/ai/turn_pipeline.py
+++ b/src/ai/turn_pipeline.py
@@ -26,7 +26,7 @@ from src.core.rule_executor import RuleContext
 if TYPE_CHECKING:
     from src.core.game_state import GameStateManager, GameState
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("deepseek.pipeline")
 
 
 class AITurnPipeline:

--- a/src/api/deepseek_client.py
+++ b/src/api/deepseek_client.py
@@ -33,7 +33,7 @@ from src.api.schemas import (
 from src.api.prompts import PromptManager, RULE_EVAL_SYSTEM
 from src.utils.config import config as global_config
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("deepseek.client")
 
 
 class APIConfig:

--- a/src/api/deepseek_helpers.py
+++ b/src/api/deepseek_helpers.py
@@ -2,7 +2,7 @@ from .deepseek_client import DeepSeekClient, APIConfig
 from src.utils.config import get_deepseek_config, is_test_mode
 from src.utils.logger import get_logger
 
-logger = get_logger(__name__)
+logger = get_logger("deepseek.helpers")
 
 
 # 便捷函数：从config目录或环境变量创建客户端


### PR DESCRIPTION
## Summary
- use `deepseek.client` logger name in DeepSeek client
- tag AI turn pipeline logs with `deepseek.pipeline`
- align helper module with `deepseek.helpers` logger

## Testing
- `pytest tests/unit -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa7834f5e48328ac6a01df4cdc818b