### PR TITLE
feat: parse CORS origins without eval

### DIFF
--- a/tests/unit/test_utils_config.py
+++ b/tests/unit/test_utils_config.py
@@ -1,0 +1,29 @@
+from src.utils.config import _parse_cors_origins, Config
+
+
+def test_parse_cors_origins_json():
+    assert _parse_cors_origins('["http://a.com", "http://b.com"]') == [
+        "http://a.com",
+        "http://b.com",
+    ]
+
+
+def test_parse_cors_origins_python_list():
+    assert _parse_cors_origins("['http://a.com', 'http://b.com']") == [
+        "http://a.com",
+        "http://b.com",
+    ]
+
+
+def test_parse_cors_origins_comma_separated():
+    assert _parse_cors_origins('http://a.com, http://b.com') == [
+        "http://a.com",
+        "http://b.com",
+    ]
+
+
+def test_get_web_config_uses_parser(monkeypatch):
+    monkeypatch.setenv('WEB_CORS_ORIGINS', 'http://a.com, http://b.com')
+    cfg = Config()
+    web = cfg.get_web_config()
+    assert web['cors_origins'] == ["http://a.com", "http://b.com"]


### PR DESCRIPTION
## Summary
- parse WEB_CORS_ORIGINS using JSON/ast/comma fallback
- replace eval in web config
- cover origin parsing with unit tests

## Testing
- `pytest tests/unit/test_utils_config.py tests/detection/test_config.py -q`
- `pytest` *(fails: HTTPConnectionPool(host='localhost',...) and missing playwright executable)*

------
https://chatgpt.com/codex/tasks/task_e_68aa80f0c6948328abf9e29cbcb87c03