### PR TITLE
feat(core): support dataclass NPC serialization

### DIFF
--- a/tests/unit/test_npc_serialization.py
+++ b/tests/unit/test_npc_serialization.py
@@ -1,0 +1,49 @@
+"""GameStateManager NPC serialization tests"""
+
+import os
+import sys
+from dataclasses import dataclass
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "../.."))
+
+from src.core.game_state import GameStateManager  # noqa: E402
+
+
+@dataclass
+class Weapon:
+    """Simple weapon dataclass for testing"""
+
+    name: str
+    damage: int
+
+
+@dataclass
+class Character:
+    """Nested dataclass for NPC"""
+
+    name: str
+    weapon: Weapon
+
+
+def test_serialize_dataclass_npc() -> None:
+    """Dataclasses should be serialized recursively"""
+
+    manager = GameStateManager()
+    npc = Character(name="Hero", weapon=Weapon(name="Sword", damage=10))
+    serialized = manager._serialize_npc(npc)
+
+    assert serialized == {"name": "Hero", "weapon": {"name": "Sword", "damage": 10}}
+
+
+def test_serialize_dataclass_in_dict() -> None:
+    """Dataclasses nested inside dictionaries should be handled"""
+
+    manager = GameStateManager()
+    npc = {"character": Character(name="Hero", weapon=Weapon(name="Sword", damage=10))}
+    serialized = manager._serialize_npc(npc)
+
+    assert serialized == {
+        "character": {"name": "Hero", "weapon": {"name": "Sword", "damage": 10}}
+    }
+


### PR DESCRIPTION
## Summary
- enhance NPC serialization to handle dataclasses and nested structures
- add tests verifying dataclass serialization

## Testing
- `pytest tests/unit/test_npc_serialization.py -q`
- `pytest tests/unit -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa81ec4a2c83289b4b73570ae911b3