### PR TITLE
feat(core): implement active effect expiration

### DIFF
--- a/src/core/side_effects.py
+++ b/src/core/side_effects.py
@@ -351,10 +351,25 @@ class SideEffectManager:
                 results.append(result)
         return results
 
-    def update_active_effects(self, current_turn: int):
-        """更新活跃副作用（移除过期的）"""
-        # 这里可以实现副作用的持续时间管理
-        pass
+    def update_active_effects(self, current_turn: int) -> None:
+        """更新活跃副作用列表并移除过期的副作用。
+
+        Args:
+            current_turn: 当前游戏回合数
+        """
+        remaining_effects = []
+        for effect in self.active_effects:
+            context = effect.get("context", {})
+            duration = context.get("duration", 1)
+            turn_applied = effect.get("turn_applied", 0)
+
+            if current_turn - turn_applied >= duration:
+                logger.info("副作用 %s 已过期", effect.get("effect_name"))
+                continue
+
+            remaining_effects.append(effect)
+
+        self.active_effects = remaining_effects
 
     def get_effects_in_location(self, location: str) -> List[Dict[str, Any]]:
         """获取指定位置的所有活跃副作用"""

--- a/tests/unit/test_side_effect_manager.py
+++ b/tests/unit/test_side_effect_manager.py
@@ -1,0 +1,21 @@
+import logging
+from src.core.side_effects import SideEffectManager
+
+
+def test_update_active_effects_expiration(caplog):
+    """Ensure expired side effects are removed based on duration."""
+    manager = SideEffectManager()
+    manager.active_effects = [
+        {"effect_name": "e1", "turn_applied": 0, "context": {"duration": 2}},
+        {"effect_name": "e2", "turn_applied": 3, "context": {"duration": 5}},
+        {"effect_name": "e3", "turn_applied": 3, "context": {}},
+    ]
+
+    with caplog.at_level(logging.INFO):
+        manager.update_active_effects(current_turn=4)
+
+    assert len(manager.active_effects) == 1
+    assert manager.active_effects[0]["effect_name"] == "e2"
+    assert "副作用 e1 已过期" in caplog.text
+    assert "副作用 e3 已过期" in caplog.text
+


### PR DESCRIPTION
## Summary
- remove expired side effects based on duration and log expiration
- add unit test for SideEffectManager expiration logic

## Testing
- `pytest tests/unit -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa845a68fc8328a4c7c19ef3fc0a3e