### PR TITLE
fix: resolve project root path in test_fixes

### DIFF
--- a/tests/unit/test_fixes.py
+++ b/tests/unit/test_fixes.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 # Add project root to path
-sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from src.models.rule import Rule, TriggerCondition, RuleEffect, EffectType
 # from src.ai.action_schema import AIAction  # TODO: 模块尚未实现


### PR DESCRIPTION
## Summary
- ensure tests/unit/test_fixes.py inserts project root using `Path(__file__).resolve().parents[2]`

## Testing
- `pytest tests/unit/test_fixes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa890dabac8328b36b60dc4aededbe