### PR TITLE
fix: validate save path in load_game endpoint

### DIFF
--- a/tests/api/test_load_game_path.py
+++ b/tests/api/test_load_game_path.py
@@ -1,0 +1,40 @@
+"""Tests for the /api/games/load endpoint path validation."""
+
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from web.backend import app as app_module
+
+
+class DummyService:
+    def get_state_response(self) -> dict:
+        return {"status": "ok"}
+
+
+@pytest.fixture
+def client():
+    return TestClient(app_module.app)
+
+
+def test_load_game_endpoint_valid(monkeypatch, tmp_path, client):
+    monkeypatch.setattr(app_module, "SAVE_DIR", tmp_path)
+
+    async def fake_load_game(filename: str):
+        assert filename == "valid.rulek"
+        return DummyService()
+
+    monkeypatch.setattr(app_module.session_manager, "load_game", fake_load_game)
+
+    response = client.post("/api/games/load", params={"filename": "valid.rulek"})
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_load_game_endpoint_invalid(client):
+    response = client.post("/api/games/load", params={"filename": "../bad.rulek"})
+    assert response.status_code == 400
+

--- a/tests/unit/test_session_manager_load_game.py
+++ b/tests/unit/test_session_manager_load_game.py
@@ -1,0 +1,46 @@
+"""SessionManager.load_game path validation tests."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from web.backend.services import session_manager as sm_module
+
+
+class DummyState:
+    game_id = "dummy"
+
+
+class DummyGameService:
+    game_state = DummyState()
+
+    async def initialize(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_load_game_valid_path(monkeypatch, tmp_path):
+    monkeypatch.setattr(sm_module, "SAVE_DIR", tmp_path)
+
+    def fake_load_from_file(cls, filename):
+        assert filename == "valid.rulek"
+        return DummyGameService()
+
+    monkeypatch.setattr(sm_module.GameService, "load_from_file", classmethod(fake_load_from_file))
+
+    manager = sm_module.SessionManager()
+    game = await manager.load_game("valid.rulek")
+
+    assert game.game_state.game_id == "dummy"
+
+
+@pytest.mark.asyncio
+async def test_load_game_invalid_path(monkeypatch, tmp_path):
+    monkeypatch.setattr(sm_module, "SAVE_DIR", tmp_path)
+
+    manager = sm_module.SessionManager()
+    with pytest.raises(ValueError):
+        await manager.load_game("../evil.rulek")
+


### PR DESCRIPTION
## Summary
- validate save path using pathlib in load_game endpoint and session manager
- add unit tests for valid and invalid save paths

## Testing
- `pre-commit run --files web/backend/app.py web/backend/services/session_manager.py tests/unit/test_session_manager_load_game.py tests/api/test_load_game_path.py`
- `pytest tests/api/test_load_game_path.py tests/unit/test_session_manager_load_game.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa8a8015c0832891adcae85f2c4137