### PR TITLE
feat(game): add ambient random events

### DIFF
--- a/tests/unit/test_random_event.py
+++ b/tests/unit/test_random_event.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+# ensure project root in sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from web.backend.services import game_service as gs_module
+from web.backend.services.game_service import GameService
+
+
+@pytest.mark.asyncio
+async def test_random_event_generation(monkeypatch):
+    """随机事件应记录在 events 列表和 game_log 中"""
+    monkeypatch.setattr(gs_module.random, "random", lambda: 0.1)
+    monkeypatch.setattr(gs_module.random, "choice", lambda seq: "窗外传来诡异声响")
+
+    service = GameService()
+    await service.initialize()
+
+    service.npc_behavior.decide_action = lambda *args, **kwargs: None
+    service.rule_executor.execute = lambda *args, **kwargs: None
+
+    async def fake_dialogue(self):
+        return []
+
+    async def fake_broadcast(self, update):
+        return None
+
+    async def fake_narrative(*args, **kwargs):
+        return None
+
+    service.narrator.generate_narrative = fake_narrative
+    monkeypatch.setattr(GameService, "_run_dialogue_phase", fake_dialogue)
+    monkeypatch.setattr(GameService, "broadcast_update", fake_broadcast)
+
+    result = await service.advance_turn()
+
+    assert any(e["type"] == "ambient" for e in result.events)
+    assert any("窗外传来诡异声响" in log for log in service.game_state_manager.game_log)
+

--- a/web/backend/services/game_service.py
+++ b/web/backend/services/game_service.py
@@ -9,6 +9,7 @@ from fastapi import WebSocket
 import json
 import uuid
 import logging
+import random
 from pathlib import Path
 import httpx
 
@@ -240,8 +241,18 @@ class GameService:
                     "result": result
                 })
         
-        # 4. 随机事件（占位）
-        # TODO: 实现基于新的事件模型的随机事件逻辑
+        # 4. 随机事件
+        random_events = [
+            "窗外传来诡异声响",
+            "远处传来微弱的哭泣声",
+            "突然一阵冷风袭来",
+        ]
+        if random.random() < 0.25:
+            description = random.choice(random_events)
+            event = {"type": "ambient", "description": description}
+            events.append(event)
+            if self.game_state_manager:
+                self.game_state_manager.log(description)
         
         # 5. 生成叙事
         narrative = None


### PR DESCRIPTION
## Summary
- add 25% chance ambient events during turn advancement
- log ambient events for future reference
- test that ambient events populate events list and game log

## Testing
- `python -m pytest tests/unit/test_random_event.py::test_random_event_generation -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa8dbd8f148328958360f0411021e0